### PR TITLE
Use ssh-keygen -A to regenerate ssh host keys

### DIFF
--- a/vmm/dev/scripts/cfgpre
+++ b/vmm/dev/scripts/cfgpre
@@ -69,8 +69,7 @@ fi
 #Regenerate ssh host keys
 WriteInfo "Regenerating ssh host keys" ${thisscript}
 	rm -rf /etc/ssh/ssh_host_*key*
-	ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N ''
-	ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N '' 
+	ssh-keygen -A
 
 GetDistroFamily
 


### PR DESCRIPTION
(Closes: #6)

This option has been around in ssh-keygen since 2011 [1] so it should be
available in any recent distribution.

[1]: https://github.com/openssh/openssh-portable/commit/58f1bafb3d4cf0965ebcb65d94b3476b959f42d8